### PR TITLE
django version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ charset-normalizer==2.0.4
 click==8.0.1
 cryptography==3.4.7
 decorator==5.0.9
-django>=3.2.12
+django==3.2.12
 django-common-helpers==0.9.2
 django-cron==0.5.1
 django-mysql-geventpool==0.2.5


### PR DESCRIPTION
The Latest Django version breaks the functionality! So we have to use Django 3.2.12! For the latest version, we have to upgrade the script's code!